### PR TITLE
Expands upon the ID filtering for items and events

### DIFF
--- a/common/helpers.ts
+++ b/common/helpers.ts
@@ -186,3 +186,48 @@ export function itemSpoilerFilter(spoilers: Spoilers): (item: Item) => boolean {
     }
   };
 }
+
+type Ranges = { start: number; end: number }[];
+
+/**
+ * Parses a string of "ranges" into an array of range objects.
+ * EG: "1-10,92" => [{ start: 1, end : 10 }, { start: 92, end: 92 }].
+ * @param str The string to parse into ranges.
+ * @returns The range objects, or null if empty input string or error.
+ */
+export function parseRanges(str: string): Ranges | null {
+  if (str === "") {
+    return null;
+  }
+  const result: Ranges = [];
+
+  for (const segment of str.split(",")) {
+    const parts = segment.split("-");
+    if (parts.length === 2) {
+      const [start, end] = parts;
+      result.push({ start: parseInt(start), end: parseInt(end) });
+    } else if (parts.length === 1) {
+      const val = parseInt(parts[0]);
+      result.push({ start: val, end: val });
+    } else {
+      return null;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Determines whether the supplied number is contained within any of the
+ * supplied ranges (inclusive of endpoints). EG:
+ *
+ * `isInRanges(10, [{ start: 1, end : 10 }, { start: 92, end: 92 }]) => true`
+ *
+ * `isInRanges(14, [{ start: 1, end : 10 }, { start: 92, end: 92 }]) => false`
+ * @param n The number to check if in any range
+ * @param ranges The ranges to check
+ * @returns `true` if n is in any range, `false` otherwise
+ */
+export function isInRanges(n: number, ranges: Ranges): boolean {
+  return ranges.some((range) => range.start <= n && n <= range.end);
+}

--- a/pages/[game]/events.tsx
+++ b/pages/[game]/events.tsx
@@ -13,6 +13,8 @@ import { useSpoilers } from "../../hooks/useSpoilers";
 import {
   getCharacterColor,
   getTitle,
+  isInRanges,
+  parseRanges,
   verifyQueryParam,
 } from "../../common/helpers";
 import { Event, Option } from "../../common/types";
@@ -107,7 +109,7 @@ const Events = ({ searchResults }: PageProps) => {
   };
 
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setSearch(parseInt(e.target.value, 10));
+    setSearch(parseRanges(e.target.value));
   };
 
   useEffect(() => {
@@ -117,7 +119,9 @@ const Events = ({ searchResults }: PageProps) => {
     );
   }, []);
 
-  const cardList = searchResults.filter((e) => !search || e.name === search);
+  const cardList = searchResults.filter(
+    (e) => !search || isInRanges(e.name, search)
+  );
 
   return (
     <Layout title={getTitle(game, "Events")}>
@@ -132,7 +136,7 @@ const Events = ({ searchResults }: PageProps) => {
             <input
               className="id-filter"
               onChange={handleSearchChange}
-              type="number"
+              placeholder="1-10,15"
             />
           </div>
           {game === "fh" ? (

--- a/pages/[game]/items.tsx
+++ b/pages/[game]/items.tsx
@@ -9,7 +9,9 @@ import {
   getCharacterColor,
   getDescription,
   getTitle,
+  isInRanges,
   itemSpoilerFilter,
+  parseRanges,
   verifyQueryParam,
 } from "../../common/helpers";
 import { Item, Option } from "../../common/types";
@@ -101,7 +103,7 @@ const Items = ({ searchResults }: PageProps) => {
   const game = verifyQueryParam(router.query.game, "gh");
 
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setSearch(parseInt(e.target.value, 10));
+    setSearch(parseRanges(e.target.value));
   };
 
   useEffect(() => {
@@ -113,7 +115,7 @@ const Items = ({ searchResults }: PageProps) => {
 
   const cardList = searchResults
     ?.filter(itemSpoilerFilter(spoilers))
-    .filter((i) => !search || i.id === search);
+    .filter((i) => !search || isInRanges(i.id, search));
 
   return (
     <Layout
@@ -131,7 +133,7 @@ const Items = ({ searchResults }: PageProps) => {
             <input
               className="id-filter"
               onChange={handleSearchChange}
-              type="number"
+              placeholder="1-10,15"
             />
           </div>
           <ItemFilters />

--- a/public/global.css
+++ b/public/global.css
@@ -414,7 +414,7 @@ input[type="radio"] {
   margin: 0 8px;
   padding: 2px 8px;
   text-align: right;
-  width: 44px;
+  width: 65px;
 }
 
 .filters {


### PR DESCRIPTION
This basically allows for specifying more than just a single ID in the Item ID / event ID filters on those pages, and instead can now specify individual numbers as well as ranges, and combinations of these too. For example:

- "27" will still match just card ID 27
- "1-10, 15" will match all cards from 1 through 10, as well as card 15 (total of 16 cards)