### PR TITLE
Revert streching cards fix

### DIFF
--- a/components/CardList.tsx
+++ b/components/CardList.tsx
@@ -20,7 +20,7 @@ const Card = ({ card, horizontal, showId }: CardProps) => {
   return (
     <div className={horizontal ? "card-horizontal" : "card"}>
       {showId && <div className="card-id">{card.id}</div>}
-      <div className="card-inner">
+      <div className="card-inner" style={{ paddingTop: horizontal ? "66%" : "150%" }}>
         <div className="card-img-front">
           <span aria-hidden="true" className="invisible">
             {card.name}
@@ -46,6 +46,7 @@ const FlipCard = ({ card, flipped, handleBtnClick, horizontal, showId }: FlipCar
       {showId && <div className="card-id">{card.id}</div>}
       <div
         className={`card-inner ${flipped ? "card-inner-flipped" : ""}`}
+        style={{ paddingTop: horizontal ? "66%" : "150%" }}
       >
         <div className="card-img-front">
           <span aria-hidden="true" className="invisible">

--- a/public/global.css
+++ b/public/global.css
@@ -167,9 +167,9 @@ input[type="radio"] {
 }
 
 .card-img {
-  display: block;
   border-radius: 12px;
   text-align: center;
+  height: 100%;
   width: 100%;
 }
 
@@ -184,7 +184,6 @@ input[type="radio"] {
     -webkit-transform 600ms;
   transform-style: preserve-3d;
   width: 100%;
-  position: relative;
   -webkit-transform-style: preserve-3d;
 }
 
@@ -196,8 +195,11 @@ input[type="radio"] {
 .card-img-back {
   backface-visibility: hidden;
   transform-style: preserve-3d;
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
+  height: 100%;
   -webkit-backface-visibility: hidden;
   -webkit-transform-style: preserve-3d;
 }
@@ -205,16 +207,6 @@ input[type="radio"] {
 .card-img-back {
   transform: rotateY(180deg);
   -webkit-transform: rotateY(180deg);
-}
-
-/* Only for cards that have both front and back (flip cards) */
-.card-inner:has(.card-img-back) {
-  position: relative;
-}
-
-.card-inner:has(.card-img-back) .card-img-front,
-.card-inner:has(.card-img-back) .card-img-back {
-  position: absolute;
 }
 
 .card-id {


### PR DESCRIPTION
Reverting this fix https://github.com/cmlenius/gloomhaven-card-browser/pull/73 because its causing event cards to be buggy.

<img width="1113" height="726" alt="Screenshot 2026-04-05 at 21 49 23" src="https://github.com/user-attachments/assets/127de13b-5555-4f0f-a9fe-f4078178d210" />
