### PR TITLE
Footer and Header improvements

### DIFF
--- a/components/pages/CharactersPage.tsx
+++ b/components/pages/CharactersPage.tsx
@@ -232,10 +232,22 @@ const CharactersPage = ({ character, game, searchResults }: PageProps) => {
           <div>
             <div className="button-group">
               <button
-                className={!showCharacterDetails ? "btn-selected" : ""}
-                onClick={() => setShowCharacterDetails(false)}
+                className={!showCharacterDetails && !isCraftingMode ? "btn-selected" : ""}
+                onClick={() => {
+                  setShowCharacterDetails(false);
+                  if (isCraftingMode) toggleCraftingMode();
+                }}
               >
                 Ability Cards
+              </button>
+              <button
+                className={!showCharacterDetails && isCraftingMode ? "btn-selected" : ""}
+                onClick={() => {
+                  if (showCharacterDetails) setShowCharacterDetails(false);
+                  if (!isCraftingMode) toggleCraftingMode();
+                }}
+              >
+                Build Mode
               </button>
               <button
                 className={showCharacterDetails ? "btn-selected" : ""}
@@ -243,14 +255,6 @@ const CharactersPage = ({ character, game, searchResults }: PageProps) => {
               >
                 Character Details
               </button>
-              {!showCharacterDetails && (
-                <button
-                  className={isCraftingMode ? "btn-selected" : ""}
-                  onClick={toggleCraftingMode}
-                >
-                  Build Mode
-                </button>
-              )}
             </div>
           </div>
         </div>
@@ -260,13 +264,15 @@ const CharactersPage = ({ character, game, searchResults }: PageProps) => {
         (showCharacterDetails ? (
           <CharacterDetails character={character} spoilers={spoilers} />
         ) : (
-          <CardList
-            cardList={cardList}
-            isCraftingMode={isCraftingMode}
-            activeDeck={activeDeck}
-            characterColour={character?.colour}
-            onCardToggle={(image) => toggleCard(image, character?.class, maxHandSize)}
-          />
+          <div style={{ paddingBottom: isCraftingMode ? "80px" : "0" }}>
+            <CardList
+              cardList={cardList}
+              isCraftingMode={isCraftingMode}
+              activeDeck={activeDeck}
+              characterColour={character?.colour}
+              onCardToggle={(image) => toggleCard(image, character?.class, maxHandSize)}
+            />
+          </div>
         ))}
 
       {isCraftingMode && !showCharacterDetails && (
@@ -278,20 +284,17 @@ const CharactersPage = ({ character, game, searchResults }: PageProps) => {
             Cards Selected: {activeDeck.length} / {maxHandSize}
           </span>
           <div className="build-toolbar-buttons">
-            <button
-              className={!viewActiveHand ? "btn-selected" : ""}
-              onClick={() => viewActiveHand && toggleViewActiveHand()}
-            >
-              All Cards
-            </button>
-            <button
-              className={viewActiveHand ? "btn-selected" : ""}
-              onClick={() => !viewActiveHand && toggleViewActiveHand()}
-            >
-              Active Hand
+            <button onClick={toggleViewActiveHand}>
+              {viewActiveHand ? "View All Cards" : "View Active Hand"}
             </button>
             <button onClick={handleShare}>Share</button>
-            <button onClick={clearDeck}>Clear</button>
+            <button onClick={() => {
+              clearDeck();
+              setToastMessage("Active Hand Cleared!");
+              if (viewActiveHand) {
+                toggleViewActiveHand();
+              }
+            }}>Clear</button>
           </div>
         </div>
       )}


### PR DESCRIPTION
After mobile testing, I have designed a few QOL improvements:

1. Button Ordering: Instead of 
<img width="538" height="71" alt="image" src="https://github.com/user-attachments/assets/cee0b41e-7a7e-43f4-b1c9-e9e600b02717" />
we have now
<img width="524" height="72" alt="image" src="https://github.com/user-attachments/assets/15c3d0d9-1a6d-477f-b112-8a6b5d6f4fb7" />
and Build Mode does not dissapear when clicking on Character Details

---

2. Footers:
- Buttons: changed the buttons so that there are only 3, less crammed
<img width="665" height="117" alt="image" src="https://github.com/user-attachments/assets/f6b1c60d-4ba3-4c00-aa70-3c2f8e3e9c4c" />

---

3. Clear buttons:
Shows toast message and shows all cards, instead of staying in Active Hand.
