### PR TITLE
Fix Frosthaven events filtering

### DIFF
--- a/components/CardList.tsx
+++ b/components/CardList.tsx
@@ -281,7 +281,7 @@ const CardList = ({
 
         return card.imageBack ? (
           <FlipCardWrapper
-            key={card.name}
+            key={card.image}
             card={card}
             horizontal={horizontal}
             showId={showId}
@@ -292,7 +292,7 @@ const CardList = ({
           />
         ) : (
           <Card
-            key={card.name}
+            key={card.image}
             card={card}
             horizontal={horizontal}
             showId={showId}

--- a/components/CardList.tsx
+++ b/components/CardList.tsx
@@ -278,10 +278,11 @@ const CardList = ({
           if (!isBackCard && onCardToggle) onCardToggle(card.image);
         };
         const clickable = isCraftingMode && !isBackCard;
+        const key = card.name + "-" + card.image;
 
         return card.imageBack ? (
           <FlipCardWrapper
-            key={card.image}
+            key={key}
             card={card}
             horizontal={horizontal}
             showId={showId}

--- a/pages/[game]/events.tsx
+++ b/pages/[game]/events.tsx
@@ -89,7 +89,7 @@ const Events = ({ searchResults }: PageProps) => {
   };
 
   const handleSeasonChange = (newSeason: string | null) => {
-    if (query.season === newSeason) {
+    if (season === newSeason) {
       setSeason(null);
     } else {
       setSeason(newSeason);


### PR DESCRIPTION
Use `card.image` instead of `card.name` as the `key` in `CardList` to avoid duplicate key warnings — Frosthaven outpost/road events share numeric names across summer and winter seasons. 

Also fix the season toggle in `events.tsx` to compare against the season state variable rather than the URL query param (which is never set)

P.S. Thank you so much for making this!