### PR TITLE
bugfix: keep card list keys unique when records share a field

### DIFF
--- a/common/utils.ts
+++ b/common/utils.ts
@@ -132,10 +132,9 @@ export const getGame = (gameId: string): Game | null => {
 };
 
 /**
- * Parses a string of "ranges" into an array of range objects.
- * EG: "1-10,92" => [{ start: 1, end : 10 }, { start: 92, end: 92 }].
- * @param str The string to parse into ranges.
- * @returns The range objects, or null if empty input string or error.
+ * Comparator that sorts on the given `order` key, with fallback to the .name field.
+ * @param order Primary sort key
+ * @param direction "asc" or "desc"
  */
 export function customSort(order: string, direction: string): (a: SearchResult, b: SearchResult) => number {
   return (a, b) => {
@@ -144,8 +143,12 @@ export function customSort(order: string, direction: string): (a: SearchResult, 
       sort = 1;
     } else if (a[order] < b[order]) {
       sort = -1;
+    } else if (a.name > b.name) {
+      sort = 1;
+    } else if (a.name < b.name) {
+      sort = -1;
     } else {
-      return a.name > b.name ? 1 : -1;
+      sort = 0;
     }
     return direction === "asc" ? sort : -1 * sort;
   };

--- a/components/CardList.tsx
+++ b/components/CardList.tsx
@@ -9,6 +9,17 @@ import Empty from "./Empty";
 
 const CARDS_PER_PAGE = 12;
 
+// Some edge case cards like FH245 (Ancient Coin) can trigger React map key
+// collisions, leading to leaks.  Dedupe with a suffix for these edge cases.
+const makeKeyDeduper = () => {
+  const seen = new Map<string, number>();
+  return (base: string) => {
+    const count = (seen.get(base) || 0) + 1;
+    seen.set(base, count);
+    return count === 1 ? base : `${base}#${count}`;
+  };
+};
+
 type CardProps = {
   card: Card;
   horizontal?: boolean;
@@ -204,6 +215,8 @@ export const MultiLevelCardList = ({ cardList }: MultiLevelCardListProp) => {
 
   if (data?.length === 0) return <Empty />;
 
+  const dedupeKey = makeKeyDeduper();
+
   return (
     <InfiniteScroll
       className="card-list"
@@ -213,7 +226,7 @@ export const MultiLevelCardList = ({ cardList }: MultiLevelCardListProp) => {
       pageStart={0}
     >
       {data?.map((multiLevelCard) => (
-        <MultiLevelCard key={multiLevelCard.id} multiLevelCard={multiLevelCard} />
+        <MultiLevelCard key={dedupeKey(String(multiLevelCard.id))} multiLevelCard={multiLevelCard} />
       ))}
       {[...Array(4)].map((_, idx) => (
         <div key={idx}>
@@ -258,6 +271,8 @@ const CardList = ({
 
   if (data?.length === 0) return <Empty />;
 
+  const dedupeKey = makeKeyDeduper();
+
   return (
     <InfiniteScroll
       className="card-list"
@@ -278,7 +293,7 @@ const CardList = ({
           if (!isBackCard && onCardToggle) onCardToggle(card.image);
         };
         const clickable = isCraftingMode && !isBackCard;
-        const key = card.name + "-" + card.image;
+        const key = dedupeKey(card.imageBack ? card.name + "-" + card.image : card.image);
 
         return card.imageBack ? (
           <FlipCardWrapper
@@ -293,7 +308,7 @@ const CardList = ({
           />
         ) : (
           <Card
-            key={card.image}
+            key={key}
             card={card}
             horizontal={horizontal}
             showId={showId}

--- a/pages/[game]/buildings.tsx
+++ b/pages/[game]/buildings.tsx
@@ -81,7 +81,8 @@ export const getStaticPaths: GetStaticPaths<GameParams> = async () => {
 
 const buildingSearchResults = (query: { [key: string]: string | string[] }) => {
   const game = verifyQueryParam(query.game, "gh");
-  return buildingCards[game]?.sort(customSort("id", "asc")) || [];
+  // Copy first: sort() reorders in place, and this is the shared module-level array.
+  return [...(buildingCards[game] || [])].sort(customSort("id", "asc"));
 };
 
 export const getStaticProps: GetStaticProps<PageProps, GameParams> = async (context) => {

--- a/pages/[game]/events.tsx
+++ b/pages/[game]/events.tsx
@@ -176,7 +176,8 @@ const eventSearchResults = (query: { [key: string]: string | string[] }) => {
 
   if (game === "fh" && eventType === "city") eventType = "outpost";
 
-  return eventCards[game]?.sort(customSort("id", "asc")) || [];
+  // Copy first: sort() reorders in place, and this is the shared module-level array.
+  return [...(eventCards[game] || [])].sort(customSort("id", "asc"));
 };
 
 export const getStaticProps: GetStaticProps<PageProps, GameParams> = async (context) => {

--- a/pages/[game]/items.tsx
+++ b/pages/[game]/items.tsx
@@ -207,7 +207,8 @@ export const getStaticPaths: GetStaticPaths<GameParams> = async () => {
 
 const itemSearchResults = (query: { [key: string]: string | string[] }) => {
   const game = verifyQueryParam(query.game, "gh");
-  return itemCards[game]?.sort(customSort("id", "asc")) || [];
+  // Copy first: sort() reorders in place, and this is the shared module-level array.
+  return [...(itemCards[game] || [])].sort(customSort("id", "asc"));
 };
 
 export const getStaticProps: GetStaticProps<PageProps, GameParams> = async (context) => {

--- a/pages/[game]/pets.tsx
+++ b/pages/[game]/pets.tsx
@@ -47,7 +47,8 @@ export const getStaticPaths: GetStaticPaths<GameParams> = async () => {
 
 const petSearchResults = (query: { [key: string]: string | string[] }) => {
   const game = verifyQueryParam(query.game, "gh");
-  return petCards[game]?.sort(customSort("id", "asc")) || [];
+  // Copy first: sort() reorders in place, and this is the shared module-level array.
+  return [...(petCards[game] || [])].sort(customSort("id", "asc"));
 };
 
 export const getStaticProps: GetStaticProps<PageProps, GameParams> = async (context) => {


### PR DESCRIPTION
Entering a list of IDs in the "Item ID" box on `/fh/items` leaves stale cards on screen — copies of item 245 (Ancient Coin), interleaved at wrong positions, for an item that was never requested.

`CardList` keys each card on `card.image`; 79471c7 moved it off `card.name` for exactly this reason, when Frosthaven events shared numeric names across seasons. Neither field is guaranteed unique. Frosthaven item 245 is four records sharing one image path, so the items page renders four siblings with the same key.  React gathers the children it may unmount into a `Map` keyed by `key`, so duplicates overwrite one another there and the shadowed nodes are never marked for deletion. They survive the commit, sitting wherever they already were — hence the wrong positions.

This PR fixes that by using a suffix on repeated keys so sibling keys are unique. The suffixing commit is the most important one.  The sort commits are needed to prepare for fixing the item 245 duplication issues in a subsequent PR.

Repro steps:
1. load `/fh/items` path
2. select "Name" in the sort box (this loads item Ancient Coin objects)
3. select "Item Number" in the sort box
4. enter `10, 20, 245` in the "Item ID" box

Without the fix, after step 3 likely shows Ancient Coin (245) cards when it should not and all Ancient Coin cards after steps 3 and 4 are the "1/4" image.  With the fix, no spurious Ancient Coins are shown after step 3 and the cards after step 4 correctly show four copies of "Ancient Coin 1/4" cards.

### Verifying the Fix

Reproduced and fixed with a headless browser against `npm run dev`, reading what is actually mounted in the DOM. Some repro helper scripts are squirelled away at https://gist.github.com/goodell/ed7b0227b854d30d6f6bbc716697cc9e.  Before/after headless screenshots will be attached in PR comments.

The `customSort` change was checked separately against a throwaway test harness in vitest, but I didn't add to avoid pulling in new deps.  I'm happy to provide an automated test in whatever form you'd prefer if desired.